### PR TITLE
Filter port invalid MTU configuration

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -4171,7 +4171,7 @@ def _get_all_mgmtinterface_keys():
 @interface.command()
 @click.pass_context
 @click.argument('interface_name', metavar='<interface_name>', required=True)
-@click.argument('interface_mtu', metavar='<interface_mtu>', required=True)
+@click.argument('interface_mtu', metavar='<interface_mtu>', required=True, type=click.IntRange(68, 9216))
 @click.option('-v', '--verbose', is_flag=True, help="Enable verbose output")
 def mtu(ctx, interface_name, interface_mtu, verbose):
     """Set interface mtu"""


### PR DESCRIPTION
#### What I did
Filter port invalid MTU configuration

#### How I did it
Adjust the MTU value to the range of [68,9216]

#### How to verify it
Use "config interface mtu Ethernet1 40" command to configure the port MTU. The following error will occur in SWSS.
```
Sep 16 14:53:39.051202 sonic NOTICE swss#orchagent: :- doPortTask: Set port Ethernet1 MTU to 40
Sep 16 14:53:39.052217 sonic INFO swss#/supervisord: portmgrd Error: mtu less than device minimum.
Sep 16 14:53:39.052600 sonic ERR swss#portmgrd: :- main: Runtime error: /sbin/ip link set dev "Ethernet1" mtu "40" : 
Sep 16 14:53:39.325117 sonic INFO swss#supervisord 2022-09-16 06:53:39,324 INFO exited: portmgrd (exit status 255; not expected)
Sep 16 14:53:40.339256 sonic INFO swss#/supervisor-proc-exit-listener: Process 'portmgrd' exited unexpectedly. Terminating supervisor 'swss'
Sep 16 14:53:40.352537 sonic INFO swss#supervisord 2022-09-16 06:53:40,339 WARN received SIGTERM indicating exit request
```

We use the iproute tool to set the kernel MTU in portmgrd. The command is:
```
ip link set dev <port_name> mtu <mtu>
```

I have tested that iproute tool will not report an error when the MTU is in the 68-9216 range.
```
root@sonic:/home/admin# ip link set dev Ethernet10 mtu 68
root@sonic:/home/admin# ifconfig Ethernet10          
Ethernet10: flags=4099<UP,BROADCAST,MULTICAST>  mtu 68
        inet 10.0.0.18  netmask 255.255.255.254  broadcast 0.0.0.0
        ether 58:69:6c:fb:21:38  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 0  bytes 0 (0.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

root@sonic:/home/admin# ip link set dev Ethernet10 mtu 67
Error: mtu less than device minimum.
root@sonic:/home/admin# 
root@sonic:/home/admin# ip link set dev Ethernet10 mtu 9216
root@sonic:/home/admin# ifconfig Ethernet10            
Ethernet10: flags=4099<UP,BROADCAST,MULTICAST>  mtu 9216
        inet 10.0.0.18  netmask 255.255.255.254  broadcast 0.0.0.0
        ether 58:69:6c:fb:21:38  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 0  bytes 0 (0.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

root@sonic:/home/admin# 
root@sonic:/home/admin# 
root@sonic:/home/admin# ip link set dev Ethernet10 mtu 9217
RTNETLINK answers: Invalid argument
root@sonic:/home/admin#
```
